### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,16 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+    cookie: {
+        httpOnly: true
+    }
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,12 @@
+import request from 'supertest';
+import app from './app';
+
+describe('Session Middleware', () => {
+  it('should set the httpOnly flag for session cookies', async () => {
+    const response = await request(app).get('/example');
+    const setCookieHeader = response.headers['set-cookie'];
+
+    expect(setCookieHeader).toBeDefined();
+    expect(setCookieHeader).toContain('HttpOnly');
+  });
+});


### PR DESCRIPTION
Default session middleware settings: `httpOnly` not set. It ensures the cookie is sent only over HTTP(S), not client JavaScript, helping to protect against cross-site scripting attacks. 	 This is a auto-generated Pull Request by Codaid which fixes the security issue in the codebase.