### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,12 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    path: '/',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import express from 'express';
+
+const app = express();
+
+app.use(expressSession({
+    secret: 'mysecret',
+    resave: false,
+    saveUninitialized: true,
+    cookie: { secure: true }
+}));
+
+app.get('/example', function(req, res) {
+    res.end(`I'm in danger!`);
+});
+
+describe('Security Test', () => {
+    it('should not expose sensitive information in the response', async () => {
+        const response = await request(app).get('/example');
+        expect(response.text).not.toContain("I'm in danger!");
+    });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Default session middleware settings: `path` not set. It indicates the path of the cookie; use it to compare against the request path. If this and domain match, then send the cookie in the request. 