### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,15 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    secret: 'your-secret-key',
+    resave: false,
+    saveUninitialized: true,
+    cookie: { secure: true, httpOnly: true, expires: new Date(Date.now() + 3600000) }
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import express from 'express';
+
+const app = express();
+
+app.use(expressSession({
+    secret: 'mysecret',
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+        secure: true,
+        httpOnly: true,
+        sameSite: 'strict',
+        expires: new Date(Date.now() + 3600000) // Set expiration date for persistent cookies
+    }
+}));
+
+describe('GET /example', () => {
+    it('should return "I\'m in danger!"', async () => {
+        const res = await request(app).get('/example');
+        expect(res.text).toBe("I'm in danger!");
+    });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Default session middleware settings: `expires` not set. Use it to set expiration date for persistent cookies. 