### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,13 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,21 @@
+Here is the test code for the security issue in the provided code:
+
+```javascript
+const request = require('supertest');
+const express = require('express');
+const app = express();
+
+app.use(expressSession({ secret: 'test-secret' }));
+
+describe('GET /example', () => {
+  it('should return "I\'m in danger!"', async () => {
+    const res = await request(app)
+      .get('/example')
+      .expect(200);
+
+    expect(res.text).toBe("I'm in danger!");
+  });
+});
+```
+
+This test code uses the `supertest` library to send a GET request to the `/example` endpoint and expects a response with a status code of 200 and the text "I'm in danger!". It also sets a custom secret for the session cookie to address the security issue mentioned in the code.


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Don’t use the default session cookie name Using the default session cookie name can open your app to attacks. The security issue posed is similar to X-Powered-By: a potential attacker can use it to fingerprint the server and target attacks accordingly. 