### PR TITLE
OWASP-A04:2017 - XML External Entities (XXE) - Fixed By CodeAid

### DIFF
--- a/test/xxe.js
+++ b/test/xxe.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import express from 'express';
+import bodyParser from 'body-parser';
+import libxmljs from 'libxmljs';
+
+const app = express();
+app.use(bodyParser.text({ type: '*/*' }));
+
+describe('XXE Vulnerability Test', () => {
+  it('should not be vulnerable to XXE attacks', (done) => {
+    const maliciousXml = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE foo [
+        <!ELEMENT foo ANY >
+        <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+      <name>&xxe;</name>
+    `;
+
+    request(app)
+      .post('/xxe')
+      .send(maliciousXml)
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.text).to.not.contain('/etc/passwd');
+        done();
+      });
+  });
+});

--- a/xxe.js
+++ b/xxe.js
@@ -8,7 +8,7 @@ const libxmljs = require('libxmljs');
 
 app.use(bodyParser.text({type: '*/*'}));
 app.post('/xxe', function(req, res) {
-    const parsed = libxmljs.parseXml(req.body, {noent: true});
+    const parsed = libxmljs.parseXml(req.body, {noent: false});
     const name = parsed.get('//name').text();
     res.end('Name is: ' + name);
 });


### PR DESCRIPTION
## What did you do?
 - [x] fixed A04:2017 - XML External Entities (XXE) 

 ## Why did you do it? 
 - The libxml library processes user-input with the `noent` attribute is set to `true` which can lead to being vulnerable to XML External Entities (XXE) type attacks. It is recommended to set `noent` to `false` when using this feature to ensure you are protected. 