### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,13 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,9 @@
+const request = require('supertest');
+const app = require('./app');
+
+describe('Session Cookie Test', () => {
+  it('should not use the default session cookie name', async () => {
+    const response = await request(app).get('/example');
+    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+  });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Don’t use the default session cookie name Using the default session cookie name can open your app to attacks. The security issue posed is similar to X-Powered-By: a potential attacker can use it to fingerprint the server and target attacks accordingly. 