### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,13 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/config.js
+++ b/config.js
@@ -12,6 +12,9 @@ app.use(bodyParser.json());
 app.use(expressSession({
     name: 'my-session-cookie',
     secret: 'my-secret-key',
+    cookie: {
+        secure: true
+    }
 }));
 
 app.get('/example', function(req, res) {

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,11 @@
-const request = require('supertest');
-const app = require('./app');
+import request from 'supertest';
+import app from './app';
 
-describe('Session Cookie Test', () => {
-  it('should not use the default session cookie name', async () => {
+describe('Session Middleware', () => {
+  it('should set secure flag for session cookie', async () => {
     const response = await request(app).get('/example');
-    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+    const sessionCookie = response.headers['set-cookie'][0];
+
+    expect(sessionCookie).toMatch(/Secure/);
   });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,9 @@
+const request = require('supertest');
+const app = require('./app');
+
+describe('Session Cookie Test', () => {
+  it('should not use the default session cookie name', async () => {
+    const response = await request(app).get('/example');
+    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+  });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Default session middleware settings: `secure` not set. It ensures the browser only sends the cookie over HTTPS. 