### PR TITLE
OWASP-A02:2017 - Broken Authentication - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,13 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/config.js
+++ b/config.js
@@ -12,6 +12,9 @@ app.use(bodyParser.json());
 app.use(expressSession({
     name: 'my-session-cookie',
     secret: 'my-secret-key',
+    cookie: {
+        secure: true
+    }
 }));
 
 app.get('/example', function(req, res) {

--- a/session.js
+++ b/session.js
@@ -10,7 +10,12 @@ const session = require('express-session')
 
 app.use(urlencoded({ extended: true }));
 app.use('/', staticServer('./static/'));
-app.use(session({secret: 'secret'}));
+app.use(session({
+    secret: 'secret',
+    cookie: {
+        secure: true
+    }
+}));
 
 
 const users = {

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,11 @@
-const request = require('supertest');
-const app = require('./app');
+import request from 'supertest';
+import app from './app';
 
-describe('Session Cookie Test', () => {
-  it('should not use the default session cookie name', async () => {
+describe('Session Middleware', () => {
+  it('should set secure flag for session cookie', async () => {
     const response = await request(app).get('/example');
-    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+    const sessionCookie = response.headers['set-cookie'][0];
+
+    expect(sessionCookie).toMatch(/Secure/);
   });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,9 @@
+const request = require('supertest');
+const app = require('./app');
+
+describe('Session Cookie Test', () => {
+  it('should not use the default session cookie name', async () => {
+    const response = await request(app).get('/example');
+    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+  });
+});

--- a/test/session.js
+++ b/test/session.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+
+const app = express();
+app.use(session({ secret: 'secret', cookie: { secure: true } }));
+
+describe('Session Middleware', () => {
+  it('should set secure flag on session cookie', () => {
+    const sessionMiddleware = app._router.stack.find(
+      (middleware) => middleware.handle.name === 'session'
+    );
+
+    expect(sessionMiddleware.handle.cookie.secure).to.be.true;
+  });
+});
+
+describe('POST /session', () => {
+  it('should redirect to data page if username and password are correct', (done) => {
+    request(app)
+      .post('/session')
+      .send({ username: 'user1', password: 'password1' })
+      .expect(302)
+      .expect('Location', 'data?username=user1')
+      .end(done);
+  });
+
+  it('should return 401 if username or password is incorrect', (done) => {
+    request(app)
+      .post('/session')
+      .send({ username: 'user1', password: 'wrongpassword' })
+      .expect(401)
+      .expect('wrong username or password')
+      .end(done);
+  });
+});
+
+describe('GET /data', () => {
+  it('should return 403 if user is not logged in', (done) => {
+    request(app)
+      .get('/data')
+      .expect(403)
+      .expect('not logged in')
+      .end(done);
+  });
+
+  it('should return the data for the specified user if logged in', (done) => {
+    request(app)
+      .get('/data?username=user1')
+      .set('Cookie', 'connect.sid=s%3AsomeSessionId')
+      .expect(200)
+      .expect('This is the data for user1')
+      .end(done);
+  });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A02:2017 - Broken Authentication 

 ## Why did you do it? 
 - Default session middleware settings: `secure` not set. It ensures the browser only sends the cookie over HTTPS. 