### PR TITLE
OWASP-A01:2021 - Broken Access Control - Fixed By CodeAid

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,13 @@ const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
 
-
-// app.use(helmet());
+app.use(helmet());
 app.use(bodyParser.json());
-app.use(expressSession());
+app.use(expressSession({
+    name: 'my-session-cookie',
+    secret: 'my-secret-key',
+}));
+
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);
 });

--- a/config.js
+++ b/config.js
@@ -13,7 +13,8 @@ app.use(expressSession({
     name: 'my-session-cookie',
     secret: 'my-secret-key',
     cookie: {
-        secure: true
+        secure: true,
+        domain: 'example.com' // Set the domain of the cookie to match the server's domain
     }
 }));
 

--- a/config.js
+++ b/config.js
@@ -12,6 +12,9 @@ app.use(bodyParser.json());
 app.use(expressSession({
     name: 'my-session-cookie',
     secret: 'my-secret-key',
+    cookie: {
+        secure: true
+    }
 }));
 
 app.get('/example', function(req, res) {

--- a/config.js
+++ b/config.js
@@ -6,6 +6,7 @@ const app = express();
 const bodyParser = require('body-parser');
 const helmet = require('helmet');
 const expressSession = require('express-session');
+const csurf = require('csurf');
 
 app.use(helmet());
 app.use(bodyParser.json());
@@ -17,6 +18,7 @@ app.use(expressSession({
         domain: 'example.com' // Set the domain of the cookie to match the server's domain
     }
 }));
+app.use(csurf());
 
 app.get('/example', function(req, res) {
     res.end(`I'm in danger!`);

--- a/session.js
+++ b/session.js
@@ -13,7 +13,8 @@ app.use('/', staticServer('./static/'));
 app.use(session({
     secret: 'secret',
     cookie: {
-        secure: true
+        secure: true,
+        httpOnly: true // Added httpOnly flag to protect against cross-site scripting attacks
     }
 }));
 

--- a/session.js
+++ b/session.js
@@ -10,7 +10,12 @@ const session = require('express-session')
 
 app.use(urlencoded({ extended: true }));
 app.use('/', staticServer('./static/'));
-app.use(session({secret: 'secret'}));
+app.use(session({
+    secret: 'secret',
+    cookie: {
+        secure: true
+    }
+}));
 
 
 const users = {

--- a/test/config.js
+++ b/test/config.js
@@ -1,11 +1,28 @@
-import request from 'supertest';
-import app from './app';
+Here is the test code for the part of the code where the security issue is present:
 
-describe('Session Middleware', () => {
-  it('should set secure flag for session cookie', async () => {
-    const response = await request(app).get('/example');
-    const sessionCookie = response.headers['set-cookie'][0];
+```javascript
+const request = require('supertest');
+const app = require('./app');
 
-    expect(sessionCookie).toMatch(/Secure/);
+describe('GET /example', () => {
+  it('should return a 200 status code', async () => {
+    const res = await request(app).get('/example');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('should not expose sensitive information', async () => {
+    const res = await request(app).get('/example');
+    expect(res.text).not.toContain("I'm in danger!");
   });
 });
+```
+
+Please note that this test assumes that you have set up the Express app in a separate file named `app.js`. You may need to modify the import statement `const app = require('./app');` to match the actual file path.
+
+Make sure to install the `supertest` package before running the test:
+
+```
+npm install supertest --save-dev
+```
+
+This test will check if the `/example` endpoint returns a 200 status code and does not expose the sensitive information "I'm in danger!".

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,11 @@
-const request = require('supertest');
-const app = require('./app');
+import request from 'supertest';
+import app from './app';
 
-describe('Session Cookie Test', () => {
-  it('should not use the default session cookie name', async () => {
+describe('Session Middleware', () => {
+  it('should set secure flag for session cookie', async () => {
     const response = await request(app).get('/example');
-    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+    const sessionCookie = response.headers['set-cookie'][0];
+
+    expect(sessionCookie).toMatch(/Secure/);
   });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,28 +1,10 @@
-Here is the test code for the part of the code where the security issue is present:
+import request from 'supertest';
+import app from './app';
 
-```javascript
-const request = require('supertest');
-const app = require('./app');
-
-describe('GET /example', () => {
-  it('should return a 200 status code', async () => {
-    const res = await request(app).get('/example');
-    expect(res.statusCode).toBe(200);
-  });
-
-  it('should not expose sensitive information', async () => {
-    const res = await request(app).get('/example');
-    expect(res.text).not.toContain("I'm in danger!");
+describe('CSRF Middleware', () => {
+  it('should include CSRF middleware', async () => {
+    const response = await request(app).get('/example');
+    expect(response.status).toBe(403);
+    expect(response.text).toBe('Forbidden');
   });
 });
-```
-
-Please note that this test assumes that you have set up the Express app in a separate file named `app.js`. You may need to modify the import statement `const app = require('./app');` to match the actual file path.
-
-Make sure to install the `supertest` package before running the test:
-
-```
-npm install supertest --save-dev
-```
-
-This test will check if the `/example` endpoint returns a 200 status code and does not expose the sensitive information "I'm in danger!".

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,9 @@
+const request = require('supertest');
+const app = require('./app');
+
+describe('Session Cookie Test', () => {
+  it('should not use the default session cookie name', async () => {
+    const response = await request(app).get('/example');
+    expect(response.headers['set-cookie']).not.toContain('connect.sid');
+  });
+});

--- a/test/session.js
+++ b/test/session.js
@@ -4,53 +4,62 @@ import express from 'express';
 import session from 'express-session';
 
 const app = express();
-app.use(session({ secret: 'secret', cookie: { secure: true } }));
 
-describe('Session Middleware', () => {
-  it('should set secure flag on session cookie', () => {
-    const sessionMiddleware = app._router.stack.find(
-      (middleware) => middleware.handle.name === 'session'
-    );
+app.use(session({
+    secret: 'secret',
+    cookie: {
+        secure: true,
+        httpOnly: true // Added httpOnly flag to ensure cookie is not accessible by client-side JavaScript
+    }
+}));
 
-    expect(sessionMiddleware.handle.cookie.secure).to.be.true;
-  });
+app.post('/session', function(req, res) {
+    // Test code for /session route
 });
 
-describe('POST /session', () => {
-  it('should redirect to data page if username and password are correct', (done) => {
-    request(app)
-      .post('/session')
-      .send({ username: 'user1', password: 'password1' })
-      .expect(302)
-      .expect('Location', 'data?username=user1')
-      .end(done);
-  });
-
-  it('should return 401 if username or password is incorrect', (done) => {
-    request(app)
-      .post('/session')
-      .send({ username: 'user1', password: 'wrongpassword' })
-      .expect(401)
-      .expect('wrong username or password')
-      .end(done);
-  });
+app.get('/data', function(req, res) {
+    // Test code for /data route
 });
 
-describe('GET /data', () => {
-  it('should return 403 if user is not logged in', (done) => {
-    request(app)
-      .get('/data')
-      .expect(403)
-      .expect('not logged in')
-      .end(done);
-  });
+describe('Session Middleware', function() {
+    it('should set the httpOnly flag to true', function() {
+        const sessionMiddleware = app._router.stack.find(middleware => middleware.name === 'session');
+        expect(sessionMiddleware.cookie.httpOnly).to.be.true;
+    });
+});
 
-  it('should return the data for the specified user if logged in', (done) => {
-    request(app)
-      .get('/data?username=user1')
-      .set('Cookie', 'connect.sid=s%3AsomeSessionId')
-      .expect(200)
-      .expect('This is the data for user1')
-      .end(done);
-  });
+describe('/session route', function() {
+    it('should set the loggedIn flag to true and redirect to /data route if username and password are correct', function(done) {
+        request(app)
+            .post('/session')
+            .send({ username: 'user1', password: 'password1' })
+            .expect(302)
+            .expect('Location', 'data?username=user1')
+            .end(done);
+    });
+
+    it('should return 401 status code if username or password is incorrect', function(done) {
+        request(app)
+            .post('/session')
+            .send({ username: 'user1', password: 'wrongpassword' })
+            .expect(401)
+            .end(done);
+    });
+});
+
+describe('/data route', function() {
+    it('should return 403 status code if user is not logged in', function(done) {
+        request(app)
+            .get('/data')
+            .expect(403)
+            .end(done);
+    });
+
+    it('should return the data for the specified username if user is logged in', function(done) {
+        request(app)
+            .get('/data?username=user1')
+            .expect(200)
+            .expect('This is the data for user1')
+            .end(done);
+    });
 });

--- a/test/session.js
+++ b/test/session.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+
+const app = express();
+app.use(session({ secret: 'secret', cookie: { secure: true } }));
+
+describe('Session Middleware', () => {
+  it('should set secure flag on session cookie', () => {
+    const sessionMiddleware = app._router.stack.find(
+      (middleware) => middleware.handle.name === 'session'
+    );
+
+    expect(sessionMiddleware.handle.cookie.secure).to.be.true;
+  });
+});
+
+describe('POST /session', () => {
+  it('should redirect to data page if username and password are correct', (done) => {
+    request(app)
+      .post('/session')
+      .send({ username: 'user1', password: 'password1' })
+      .expect(302)
+      .expect('Location', 'data?username=user1')
+      .end(done);
+  });
+
+  it('should return 401 if username or password is incorrect', (done) => {
+    request(app)
+      .post('/session')
+      .send({ username: 'user1', password: 'wrongpassword' })
+      .expect(401)
+      .expect('wrong username or password')
+      .end(done);
+  });
+});
+
+describe('GET /data', () => {
+  it('should return 403 if user is not logged in', (done) => {
+    request(app)
+      .get('/data')
+      .expect(403)
+      .expect('not logged in')
+      .end(done);
+  });
+
+  it('should return the data for the specified user if logged in', (done) => {
+    request(app)
+      .get('/data?username=user1')
+      .set('Cookie', 'connect.sid=s%3AsomeSessionId')
+      .expect(200)
+      .expect('This is the data for user1')
+      .end(done);
+  });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A01:2021 - Broken Access Control 

 ## Why did you do it? 
 - A CSRF middleware was not detected in your express application. Ensure you are either using one such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies. 