### PR TITLE
OWASP-A01:2021 - Broken Access Control - Fixed By CodeAid

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -3,9 +3,14 @@
 const port = 3000;
 const express = require('express');
 const keys = require('node-serialize');
+const csrf = require('csurf'); // Added CSRF middleware
 const app = express();
 
-app.use(express.text({type: 'text/plain'}))
+app.use(express.text({type: 'text/plain'}));
+
+// Added CSRF middleware
+app.use(csrf());
+
 app.post('/keys', function(req, res) {
     const unserialized = keys.unserialize(req.body);
     res.end('keys are ' + Object.keys(unserialized));

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const express = require('express');
+const keys = require('node-serialize');
+
+const app = express();
+
+app.use(express.text({type: 'text/plain'}))
+app.post('/keys', function(req, res) {
+    const unserialized = keys.unserialize(req.body);
+    res.end('keys are ' + Object.keys(unserialized));
+});
+
+describe('CSRF Middleware', () => {
+    it('should have CSRF middleware', async () => {
+        const response = await request(app)
+            .post('/keys')
+            .send('data=example');
+
+        expect(response.statusCode).toBe(403);
+        expect(response.text).toBe('CSRF token missing or invalid');
+    });
+});


### PR DESCRIPTION
## What did you do?
 - [x] fixed A01:2021 - Broken Access Control 

 ## Why did you do it? 
 - A CSRF middleware was not detected in your express application. Ensure you are either using one such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies. 