### PR TITLE
OWASP-A01:2021 - Broken Access Control - Fixed By CodeAid

### DIFF
--- a/test/xss.js
+++ b/test/xss.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('./app');
+
+describe('CSRF Middleware', () => {
+  it('should have CSRF middleware', async () => {
+    const response = await request(app).get('/xss');
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['set-cookie']).toBeDefined();
+  });
+});

--- a/xss.js
+++ b/xss.js
@@ -6,8 +6,10 @@ const db = new sqlite.Database(':memory:');
 db.run('CREATE TABLE comments(ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP, comment TEXT)');
 
 const express = require('express');
+const csrf = require('csurf'); // Import csurf middleware
 const app = express();
 app.use(express.urlencoded({extended: true}));
+app.use(csrf()); // Use csurf middleware
 
 app.get('/xss', function (req, res) {
     db.all('SELECT comment FROM comments ORDER BY ts DESC', [], function(err, rows) {
@@ -18,6 +20,7 @@ app.get('/xss', function (req, res) {
                 How is DevConf.US so far?<br/>
                 <form action="/xss" method="post">
                     <input name="comment" type="text">&nbsp;<input type="submit">
+                    <input type="hidden" name="_csrf" value="${req.csrfToken()}"> // Add CSRF token as a hidden input field
                 </form>
                 <br/>
                 Here's what others are saying:<br/>


### PR DESCRIPTION
## What did you do?
 - [x] fixed A01:2021 - Broken Access Control 

 ## Why did you do it? 
 - A CSRF middleware was not detected in your express application. Ensure you are either using one such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies. 